### PR TITLE
Add klipper PAUSE compatibility to PausedForUser

### DIFF
--- a/octoprint_octopod/paused_for_user.py
+++ b/octoprint_octopod/paused_for_user.py
@@ -16,7 +16,7 @@ class PausedForUser:
 		# Firmware will print to terminal when printer has paused for user
 
 		# if line.startswith("Not SD printing"):
-		if line.startswith("echo:busy: paused for user"):
+		if line.startswith("echo:busy: paused for user") or line.startswith("// action:paused"):
 			# Check if this type of notification is disabled
 			pause_interval = settings.get_int(['pause_interval'])
 			if pause_interval == 0:


### PR DESCRIPTION
Listen for klipper's PAUSE macro terminal output "// action:paused", in addition to Marlin's "echo:busy: paused for user"