### PR TITLE
Release 0.3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ You can test the configuration before saving it by using the _Send test notifica
 
 ## Changelog
 
+**[0.3.18]** (01/20/2025)
+- NEW: Added support for [PrintTimeGenius plugin](https://plugins.octoprint.org/plugins/PrintTimeGenius/). Progress notifications will report correct progress
+- NEW: 'Printer paused for user' notification is now sent for [M0 and M1 gcode commands](https://marlinfw.org/docs/gcode/M000-M001.html)
+- FIXED: Ensure 'Notification Server URL' has no trailing slash
+
 **[0.3.17]** (11/24/2024)
 - NEW: Turn on HomeAssistant light when room is dark before taking snapshot. Requires [OctoLight Home Assistant plugin](https://plugins.octoprint.org/plugins/octolightHA/)
 - NEW: Added support to receive notifications at specific heights
@@ -172,6 +177,7 @@ You can test the configuration before saving it by using the _Send test notifica
 **[0.1.2]** (05/28/2019)
 - Initial Release
 
+[0.3.18]: https://github.com/gdombiak/OctoPrint-OctoPod/tree/0.3.18
 [0.3.17]: https://github.com/gdombiak/OctoPrint-OctoPod/tree/0.3.17
 [0.3.16]: https://github.com/gdombiak/OctoPrint-OctoPod/tree/0.3.16
 [0.3.15]: https://github.com/gdombiak/OctoPrint-OctoPod/tree/0.3.15

--- a/octoprint_octopod/__init__.py
+++ b/octoprint_octopod/__init__.py
@@ -105,7 +105,7 @@ class OctopodPlugin(octoprint.plugin.SettingsPlugin,
 	def get_settings_defaults(self):
 		return dict(
 			debug_logging=False,
-			server_url='http://octopodprint.com/',
+			server_url='http://octopodprint.com',
 			camera_snapshot_url='http://localhost:8080/?action=snapshot',
 			tokens=[],
 			sound_notification='default',

--- a/octoprint_octopod/__init__.py
+++ b/octoprint_octopod/__init__.py
@@ -232,7 +232,7 @@ class OctopodPlugin(octoprint.plugin.SettingsPlugin,
 	# progress-hook
 	def on_print_progress(self, storage, path, progress):
 		# progress 0 - 100
-		self._job_notifications.on_print_progress(self._settings, progress)
+		self._job_notifications.on_print_progress(self._settings, progress, self._printer)
 		self._live_activities.on_print_progress(self._settings, self._printer)
 
 	# EventHandlerPlugin mixin

--- a/octoprint_octopod/base_notification.py
+++ b/octoprint_octopod/base_notification.py
@@ -29,7 +29,7 @@ class BaseNotification:
 
 			# if octolight HA plugin is installed then check if room is dark and turn on the light if needed
 			octolightHA = self._plugin_manager.plugins.get("octolightHA")
-			if octolightHA and turn_on_ifneeded:
+			if octolightHA is not None and octolightHA.enabled and turn_on_ifneeded:
 				if self.__is_image_dark(image_obj):
 					# Some webcams need a sec to adapt to lighting conditions. They initially see black. Wait a sec
 					time.sleep(1)

--- a/octoprint_octopod/base_notification.py
+++ b/octoprint_octopod/base_notification.py
@@ -242,15 +242,25 @@ class BaseNotification:
 				return self._alerts.send_alert(settings, apns_token, url, printer_name, message, None, image) < 300
 
 	def _is_printer_printing(self, printer):
-		completion = None
+		(completion, print_time_in_seconds, print_time_left_in_seconds) = self._get_progress_data(printer)
+		# Check that we are in the middle of a print
+		return not(completion is None or completion == 0 or completion == 100)
+
+	def _get_progress_data(self, printer, reported_progress=None):
+		completion = None if reported_progress is None else reported_progress
+		print_time_in_seconds = None
+		print_time_left_in_seconds = None
 		current_data = printer.get_current_data()
 		if "progress" in current_data and current_data["progress"] is not None \
 				and "completion" in current_data["progress"] and current_data["progress"][
 			"completion"] is not None:
-			completion = current_data["progress"]["completion"]
+			print_time_left_in_seconds = current_data["progress"]["printTimeLeft"]
+			print_time_in_seconds = current_data["progress"]["printTime"]
+			completion = current_data["progress"]["completion"] if reported_progress is None else reported_progress
+			# Ugly hack - PrintTimeGenius changed reported completion so we need to use their conversion function
+			completion = self._convert_progress(completion, print_time_in_seconds, print_time_left_in_seconds)
+		return completion, print_time_in_seconds, print_time_left_in_seconds
 
-		# Check that we are in the middle of a print
-		return not(completion is None or completion == 0 or completion == 100)
 
 	@staticmethod
 	def _get_server_url(settings):
@@ -262,3 +272,17 @@ class BaseNotification:
 			if server_url.endswith('/'):
 				server_url = server_url[:-1]
 		return server_url
+
+	def _convert_progress(self, progress, print_time, time_left):
+		"""
+		PrintTimeGenius plugin changed the way progress is calculated. If this plugin is installed then the reported
+		progress by OctoPrint might be wrong and hence needs to be calculated based on printing time.
+		"""
+		if print_time is None or time_left is None:
+			return progress
+		# Check if PrintTimeGenius plugin is installed and enabled
+		print_time_genius_plugin = self._plugin_manager.plugins.get("PrintTimeGenius")
+		if print_time_genius_plugin is not None and print_time_genius_plugin.enabled and time_left > 0:
+			return print_time / (print_time + time_left) * 100
+		return progress
+

--- a/octoprint_octopod/job_notifications.py
+++ b/octoprint_octopod/job_notifications.py
@@ -10,7 +10,9 @@ class JobNotifications(BaseNotification):
 		BaseNotification.__init__(self, logger, plugin_manager)
 		self._ifttt_alerts = ifttt_alerts
 
-	def on_print_progress(self, settings, progress):
+	def on_print_progress(self, settings, progress, printer):
+		(completion, print_time_in_seconds, print_time_left_in_seconds) = self._get_progress_data(printer, progress)
+		progress = round(completion) if completion is not None else progress
 		progress_type = settings.get(["progress_type"])
 		if progress_type == '0':
 			# Print notification disabled
@@ -60,13 +62,9 @@ class JobNotifications(BaseNotification):
 		url = url + '/v1/push_printer'
 
 		# Gather information about progress completion of the job
-		completion = None
 		was_printing = False
 		current_data = printer.get_current_data()
-		if "progress" in current_data and current_data["progress"] is not None \
-				and "completion" in current_data["progress"] and current_data["progress"][
-			"completion"] is not None:
-			completion = current_data["progress"]["completion"]
+		(completion, print_time_in_seconds, print_time_left_in_seconds) = self._get_progress_data(printer)
 
 		current_printer_state_id = event_payload["state_id"]
 		if not test:

--- a/octoprint_octopod/live_activities.py
+++ b/octoprint_octopod/live_activities.py
@@ -136,14 +136,10 @@ class LiveActivities(BaseNotification):
 
 	def __get_notification_data(self, settings, printer):
 		url = self.__get_service_url(settings)
-		completion = None
-		print_time_left_in_seconds = None
 		current_data = printer.get_current_data()
 		printer_status = None
-		if "progress" in current_data and current_data["progress"] is not None \
-				and "completion" in current_data["progress"] and current_data["progress"]["completion"] is not None:
-			completion = round(current_data["progress"]["completion"])
-			print_time_left_in_seconds = current_data["progress"]["printTimeLeft"]
+		(completion, print_time_in_seconds, print_time_left_in_seconds) = self._get_progress_data(printer)
+		completion = round(completion) if completion is not None else None
 
 		if "state" in current_data and current_data["state"] is not None:
 			printer_status = current_data["state"]["text"]

--- a/octoprint_octopod/paused_for_user.py
+++ b/octoprint_octopod/paused_for_user.py
@@ -16,7 +16,7 @@ class PausedForUser(BaseNotification):
 		# print to terminal 'paused for user' message so this will help for those cases
 		# Prusa firmware supports M601 that is not supported by Marlin
 		if gcode:
-			if gcode == "M600" or gcode == "M601" or gcode == "M25":
+			if gcode == "M600" or gcode == "M601" or gcode == "M25" or gcode == "M0" or gcode == "M1":
 				# Check if this type of notification is disabled
 				if not self.__is_notification_enabled(settings):
 					return

--- a/octoprint_octopod/static/js/octopod.js
+++ b/octoprint_octopod/static/js/octopod.js
@@ -47,16 +47,16 @@ $(function() {
                 contentType: "application/json; charset=UTF-8",
                 success: function(response) {
                     self.testResult(true);
-                    self.testSuccessful(response.code == 204);
-                    if (response.code == -1) {
+                    self.testSuccessful(response.code === 204);
+                    if (response.code === -1) {
                         self.testMessage("Complete 'Notification Server URL'");
-                    } else if (response.code == -2) {
+                    } else if (response.code === -2) {
                         self.testMessage("No iOS devices registered yet. Open OctoPod app on your iOS device");
-                    } else if (response.code == 404) {
+                    } else if (response.code === 404) {
                         self.testMessage("404 - Notification Server URL was not found");
-                    } else if (response.code == 500) {
+                    } else if (response.code === 500) {
                         self.testMessage("500 - Target server had an error");
-                    } else if (response.code == -500) {
+                    } else if (response.code === -500) {
                         self.testMessage("There was an error sending message. Check logs");
                     } else {
                         self.testMessage(undefined);
@@ -76,7 +76,7 @@ $(function() {
             // Do nothing if inputNewLayer has no number
             const value = parseInt(self.inputNewLayer());
             if (!isNaN(value)) {
-                if (self.settings.plugins.octopod.notify_layers.indexOf(value) == -1) {
+                if (self.settings.plugins.octopod.notify_layers.indexOf(value) === -1) {
                     self.settings.plugins.octopod.notify_layers.push(value);
                     self.settings.plugins.octopod.notify_layers.sort((a, b) => a - b); // Sort layers ascending
                 }
@@ -90,6 +90,17 @@ $(function() {
 
         self.onBeforeBinding = function() {
             self.settings = self.settingsViewModel.settings;
+        };
+
+        self.sanitizeServerURL = function(data, event) {
+                const input = event.target;
+                let url = input.value.trim(); // Trim leading/trailing spaces
+
+                // Remove trailing slashes
+                url = url.replace(/\/+$/, '');
+
+                // Update the bound property directly
+                self.settings.plugins.octopod.server_url(url);
         };
     }
 

--- a/octoprint_octopod/templates/octopod_settings.jinja2
+++ b/octoprint_octopod/templates/octopod_settings.jinja2
@@ -15,7 +15,7 @@
                 <div class="control-group">
                     <label class="octopod-label" id="server_url_label">{{ _('Notification Server URL') }}</label>
                     <div class="controls">
-                        <input type="text" class="input-block-level" id="server_url" data-bind="value: settings.plugins.octopod.server_url">
+                        <input type="text" class="input-block-level" id="server_url" data-bind="value: settings.plugins.octopod.server_url, event: { blur: sanitizeServerURL }">
                         <span class="help-inline">{{ _('Enter URL address to the OctoPod server that sends Apple Push Notifications') }}</span>
                     </div>
                 </div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octopod"
 plugin_name = "OctoPrint-OctoPod"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.17"
+plugin_version = "0.3.18"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- NEW: Added support for [PrintTimeGenius plugin](https://plugins.octoprint.org/plugins/PrintTimeGenius/). Progress notifications will report correct progress
- NEW: 'Printer paused for user' notification is now sent for [M0 and M1 gcode commands](https://marlinfw.org/docs/gcode/M000-M001.html)
- FIXED: Ensure 'Notification Server URL' has no trailing slash
